### PR TITLE
fix:add hit when opening lnk in fuzzy. lnk file works in root

### DIFF
--- a/js/loader.js
+++ b/js/loader.js
@@ -3,6 +3,14 @@ define(["require", "exports", "launch", "htmltools", "./tree", "./launchquery"],
     Object.defineProperty(exports, "__esModule", { value: true });
     function isUrl(text) {
         let pattern = /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g;
+        let files = launch.getFiles();
+        console.log(files.map(x => x.getLocation()));
+        console.log(text);
+        if (files.map(x => x.getLocation()).includes(text)) {
+            console.log("is filename");
+            return false;
+        }
+        console.log("is NOT filename");
         return guardedMatch(text, pattern);
     }
     function checkHttp(text) {
@@ -205,6 +213,8 @@ define(["require", "exports", "launch", "htmltools", "./tree", "./launchquery"],
                             }
                             else {
                                 let shiftHeld = key.shiftKey ? "shift" : "";
+                                chosenFile.hits += 1;
+                                launch.store();
                                 chosenFile.execute(shiftHeld);
                                 tools.clearLaunchBox();
                                 hideFuzzy();

--- a/ts/loader.ts
+++ b/ts/loader.ts
@@ -7,7 +7,14 @@ import { LaunchFolder } from "./launchfolder";
 
 function isUrl(text:string):boolean{
     let pattern = /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g;
-
+    let files = launch.getFiles()
+    console.log(files.map(x => x.getLocation()))
+    console.log(text)
+    if (files.map(x => x.getLocation()).includes(text)) {
+        console.log("is filename")
+        return false;
+    }
+    console.log("is NOT filename")
     return guardedMatch(text, pattern)
 }
 
@@ -241,6 +248,8 @@ $(function(){
                             hideFuzzy();
                         } else {
                             let shiftHeld = key.shiftKey ? "shift" : "";
+                            chosenFile.hits += 1;
+                            launch.store();
                             chosenFile.execute(shiftHeld);
                             tools.clearLaunchBox();
                             hideFuzzy();


### PR DESCRIPTION
lnk files in root were treated as URLs, as they match the regex
now checks if the text is a file before checking if a URL