### PR TITLE
fix:remove opactity 0.8 on window class

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -78,7 +78,6 @@ a {
 
 .window {
     background-color: #333;
-    opacity: 0.8;
     display: flex;
     flex-direction: column;
     backdrop-filter: blur(15px);


### PR DESCRIPTION
bg color was already 0.5 using rgba, adding 0.8 opacity on top
just made it *bad* and text less readable!